### PR TITLE
Pull in multi_domain tracker functionality

### DIFF
--- a/app/models/spree/tracker.rb
+++ b/app/models/spree/tracker.rb
@@ -1,8 +1,19 @@
 class Spree::Tracker < ActiveRecord::Base
-  def self.current
-    tracker = where(active: true).first
-    if tracker && tracker.analytics_id.present?
-      tracker
+  belongs_to :store
+
+  def self.current(store)
+    if store.is_a?(Spree::Store)
+      Spree::Tracker.where(active: true, store_id: store).first
+    else
+      # TODO: Remove in 2.0
+      ActiveSupport::Deprecation.warn <<-EOS.squish, caller
+        Calling Spree::Tracker.current with a string is DEPRECATED. Instead
+        pass it an instance of Spree::Store.
+      EOS
+      Spree::Tracker.where(active: true).joins(:store).where(
+        "spree_stores.code = ? OR spree_stores.url LIKE ?",
+        store, "%#{store}%"
+      ).first
     end
   end
 end

--- a/app/views/spree/admin/trackers/_form.html.erb
+++ b/app/views/spree/admin/trackers/_form.html.erb
@@ -1,28 +1,32 @@
-<div data-hook="admin_tracker_form_fields" class="row">
-  <div class="alpha four columns">
-    <div data-hook="analytics_id" class="field">
-      <%= f.label :analytics_id %>
-      <%= f.text_field :analytics_id, :class => 'fullwidth' %>
+<div class="container">
+  <div data-hook="admin_tracker_form_fields" class="row">
+    <div class="col-md-3">
+      <div data-hook="analytics_id" class="field">
+        <%= f.label :analytics_id %>
+        <%= f.text_field :analytics_id, :class => 'fullwidth' %>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div data-hook="active" class="field">
+        <%= f.label :active %>
+        <ul>
+          <li>
+            <%= radio_button(:tracker, :active, true) %>
+            <%= label_tag :tracker_active_true, Spree.t(:say_yes) %>
+          </li>
+          <li>
+            <%= radio_button(:tracker, :active, false) %>
+            <%= label_tag :tracker_active_false, Spree.t(:say_no) %>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div data-hook="store_select" class="field">
+        <%= f.label :store %>
+        <div class="clear"></div>
+        <%= collection_select(:tracker, :store_id, Spree::Store.all, :id, :name, {}) %>
+      </div>
     </div>
   </div>
-  <div class="omega four columns">
-    <div data-hook="active" class="field">
-      <%= f.label :active %>
-      <ul>
-        <li>
-          <%= radio_button(:tracker, :active, true) %>
-          <%= label_tag :tracker_active_true, Spree.t(:say_yes) %>
-        </li>
-        <li>
-          <%= radio_button(:tracker, :active, false) %>
-          <%= label_tag :tracker_active_false, Spree.t(:say_no) %>
-        </li>
-      </ul>
-    </div>
-  </div>
-
-  <div class="clear"></div>
-
-  <div data-hook="additional_tracker_fields"></div>
-
 </div>

--- a/app/views/spree/admin/trackers/index.html.erb
+++ b/app/views/spree/admin/trackers/index.html.erb
@@ -24,6 +24,7 @@
       <tr data-hook="admin_trackers_index_headers">
         <th><%= Spree::Tracker.human_attribute_name(:analytics_id) %></th>
         <th><%= Spree::Tracker.human_attribute_name(:active) %></th>
+        <th><%= Spree.t(:store) %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -32,6 +33,7 @@
         <tr id="<%= spree_dom_id tracker %>" data-hook="admin_trackers_index_rows" class="<%= cycle('odd', 'even')%>">
           <td class="align-center"><%= tracker.analytics_id %></td>
           <td class="align-center"><%= tracker.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+          <td><%= tracker.store.name %></td>
           <td class="actions">
             <% if can?(:update, tracker) %>
               <%= link_to_edit tracker, :no_text => true %>

--- a/db/migrate/20160906231452_create_trackers.rb
+++ b/db/migrate/20160906231452_create_trackers.rb
@@ -1,6 +1,6 @@
 class CreateTrackers < ActiveRecord::Migration[5.0]
   def up
-    unless table_exists?("spree_trackers")
+    unless data_source_exists?("spree_trackers")
       create_table :spree_trackers do |t|
         t.string :environment
         t.string :analytics_id

--- a/db/migrate/20160920231000_add_store_to_tracker.rb
+++ b/db/migrate/20160920231000_add_store_to_tracker.rb
@@ -1,0 +1,17 @@
+class AddStoreToTracker < ActiveRecord::Migration
+  def self.up
+    if data_source_exists?('spree_trackers')
+      change_table :spree_trackers do |t|
+        t.references :store
+      end
+    end
+  end
+
+  def self.down
+    if data_source_exists?('spree_trackers')
+      change_table :spree_trackers do |t|
+        t.remove :store_id
+      end
+    end
+  end
+end

--- a/spec/features/admin/configuration/analytics_tracker_spec.rb
+++ b/spec/features/admin/configuration/analytics_tracker_spec.rb
@@ -2,10 +2,11 @@ require 'spec_helper'
 
 describe "Analytics Tracker", type: :feature do
   stub_authorization!
+  let!(:store) { create(:store) }
 
   context "index" do
     before(:each) do
-      2.times { create(:tracker) }
+      2.times { create(:tracker, store: store) }
       visit spree.admin_path
       click_link "Settings"
       click_link "Analytics Tracker"
@@ -38,6 +39,8 @@ describe "Analytics Tracker", type: :feature do
     it "should be able to create a new analytics tracker" do
       click_link "admin_new_tracker_link"
       fill_in "tracker_analytics_id", with: "A100"
+      option = first("#tracker_store_id option").text
+      select option, from: "tracker_store_id"
       click_button "Create"
 
       expect(page).to have_content("successfully created!")

--- a/spec/models/spree/tracker_spec.rb
+++ b/spec/models/spree/tracker_spec.rb
@@ -1,21 +1,37 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Tracker, type: :model do
-  let!(:tracker) { create(:tracker) }
+  let(:store) { create(:store) }
+  let!(:tracker) { create(:tracker, store: store) }
+  let(:other_store) { create(:store, code: 'STORE2', url: 'realfakedoors.com') }
+  let!(:other_tracker) { create(:tracker, store: other_store) }
 
   describe "current" do
     it "returns the first active tracker" do
-      expect(Spree::Tracker.current).to eq(tracker)
-    end
-
-    it "does not return a tracker with a blank analytics_id" do
-      tracker.update_attribute(:analytics_id, '')
-      expect(Spree::Tracker.current).to be_nil
+      expect(Spree::Tracker.current(store)).to eq(tracker)
     end
 
     it "does not return an inactive tracker" do
       tracker.update_attribute(:active, false)
-      expect(Spree::Tracker.current).to be_nil
+      expect(Spree::Tracker.current(store)).to be_nil
+    end
+
+    it "finds tracker by store" do
+      expect(Spree::Tracker.current(store)).to eq tracker
+    end
+
+    it "finds tracker based on store code" do
+      aggregate_failures do
+        expect(ActiveSupport::Deprecation).to receive(:warn)
+        expect(Spree::Tracker.current('STORE2')).to eq other_tracker
+      end
+    end
+
+    it "finds tracker based on store url" do
+      aggregate_failures do
+        expect(ActiveSupport::Deprecation).to receive(:warn)
+        expect(Spree::Tracker.current(store.url)).to eq tracker
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is largely code extracted from the `solidus_multi_domain` extension

Trackers are now associated with a store, and the partials have been expanded to accommodate this
