### PR TITLE
Fix _google_anaytics view, pass current_store as argument. 

### DIFF
--- a/app/models/spree/tracker.rb
+++ b/app/models/spree/tracker.rb
@@ -1,7 +1,8 @@
 class Spree::Tracker < ActiveRecord::Base
   belongs_to :store
 
-  def self.current(store)
+  def self.current(store = nil)
+    return if !store
     if store.is_a?(Spree::Store)
       Spree::Tracker.where(active: true, store_id: store).first
     else

--- a/app/views/spree/shared/_google_analytics.html.erb
+++ b/app/views/spree/shared/_google_analytics.html.erb
@@ -1,4 +1,4 @@
-<% if tracker = Spree::Tracker.current %>
+<% if tracker = Spree::Tracker.current(current_store) %>
 	<script>
 		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/spec/models/spree/tracker_spec.rb
+++ b/spec/models/spree/tracker_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Spree::Tracker, type: :model do
   let!(:other_tracker) { create(:tracker, store: other_store) }
 
   describe "current" do
+    it "returns nil if no store passed in argument" do
+      expect(Spree::Tracker.current).to eq(nil)
+    end
+
     it "returns the first active tracker" do
       expect(Spree::Tracker.current(store)).to eq(tracker)
     end


### PR DESCRIPTION
And allow Spree::Tracker.current to be called without store