### PR TITLE
Add ffaker dependency to gemspec

### DIFF
--- a/solidus_trackers.gemspec
+++ b/solidus_trackers.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'ffaker'
 end


### PR DESCRIPTION
ffaker was removed as a runtime dependency of Solidus here:
solidusio/solidus#2163