### PR TITLE
Add test to check if the script tag is being rendered

### DIFF
--- a/app/views/spree/shared/_google_analytics.html.erb
+++ b/app/views/spree/shared/_google_analytics.html.erb
@@ -1,5 +1,5 @@
 <% if tracker = Spree::Tracker.current(current_store) %>
-	<script>
+	<script id="solidus_trackers">
 		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/spec/features/admin/configuration/analytics_tracker_spec.rb
+++ b/spec/features/admin/configuration/analytics_tracker_spec.rb
@@ -50,4 +50,13 @@ describe "Analytics Tracker", type: :feature do
       end
     end
   end
+
+  context "store" do
+    it "should display the script tag if a tracking id is provided" do
+      create(:tracker, store: store)
+
+      visit spree.root_path
+      expect(page).to have_css('#solidus_trackers', visible: false)
+    end
+  end
 end


### PR DESCRIPTION
Added a test to check if the script tag for the tracker code is being rendered, found a scenario where the ```data-hook=body``` was deleted from the layout and therefore the script tag didn't render without noticing it until manual testing, so it would be helpful to avoid this