### PR TITLE
Add original hash to backend override

### DIFF
--- a/app/overrides/decorate_admin_configurations_index.rb
+++ b/app/overrides/decorate_admin_configurations_index.rb
@@ -3,5 +3,6 @@ Deface::Override.new(
   name: "tracker_admin_configurations_menu",
   insert_bottom: "[data-hook='admin_configurations_sidebar_menu']",
   disabled: false,
-  partial: "spree/shared/tracker_sidebar_entry"
+  partial: "spree/shared/tracker_sidebar_entry",
+  original: '1e1faff0102efd8aeec3d5f6370451d2078d01f3'
 )


### PR DESCRIPTION
Running the current code against the latest gem release of Solidus produces the following Deface warning:

````
Deface: [WARNING] No :original defined for 'tracker_admin_configurations_menu',
you should change its definition to include:
 :original => '1e1faff0102efd8aeec3d5f6370451d2078d01f3' 
````

This PR adds this hash signature, thus silencing the warning message.