### PR TITLE
Extension maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ env:
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
+    - SOLIDUS_BRANCH=v2.8 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
     - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql
     - SOLIDUS_BRANCH=v2.6 DB=mysql
     - SOLIDUS_BRANCH=v2.7 DB=mysql
+    - SOLIDUS_BRANCH=v2.8 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,12 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
     - SOLIDUS_BRANCH=v2.8 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql
     - SOLIDUS_BRANCH=v2.6 DB=mysql

--- a/Rakefile
+++ b/Rakefile
@@ -4,14 +4,11 @@ Bundler::GemHelper.install_tasks
 
 begin
   require 'spree/testing_support/extension_rake'
-  require 'rubocop/rake_task'
   require 'rspec/core/rake_task'
 
   RSpec::Core::RakeTask.new(:spec)
 
-  RuboCop::RakeTask.new
-
-  task default: %i(first_run rubocop spec)
+  task default: %i(first_run spec)
 rescue LoadError
   # no rspec available
 end

--- a/app/views/spree/admin/trackers/_form.html.erb
+++ b/app/views/spree/admin/trackers/_form.html.erb
@@ -12,11 +12,11 @@
         <ul>
           <li>
             <%= radio_button(:tracker, :active, true) %>
-            <%= label_tag :tracker_active_true, Spree.t(:say_yes) %>
+            <%= label_tag :tracker_active_true, I18n.t('spree.say_yes') %>
           </li>
           <li>
             <%= radio_button(:tracker, :active, false) %>
-            <%= label_tag :tracker_active_false, Spree.t(:say_no) %>
+            <%= label_tag :tracker_active_false, I18n.t('spree.say_no') %>
           </li>
         </ul>
       </div>

--- a/app/views/spree/admin/trackers/edit.html.erb
+++ b/app/views/spree/admin/trackers/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
-<% admin_breadcrumb(Spree.t(:settings)) %>
-<% admin_breadcrumb(Spree.t(:general_settings)) %>
+<% admin_breadcrumb(I18n.t('spree.settings')) %>
+<% admin_breadcrumb(I18n.t('spree.general_settings')) %>
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Tracker), spree.admin_trackers_path) %>
 <% admin_breadcrumb(@tracker.analytics_id) %>
 

--- a/app/views/spree/admin/trackers/index.html.erb
+++ b/app/views/spree/admin/trackers/index.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
-<% admin_breadcrumb(Spree.t(:settings)) %>
-<% admin_breadcrumb(Spree.t(:general_settings)) %>
+<% admin_breadcrumb(I18n.t('spree.settings')) %>
+<% admin_breadcrumb(I18n.t('spree.general_settings')) %>
 <% admin_breadcrumb(plural_resource_name(Spree::Tracker)) %>
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Tracker) %>
     <li>
-      <%= button_link_to Spree.t(:new_tracker), new_object_url, :id => 'admin_new_tracker_link' %>
+      <%= link_to I18n.t('spree.new_tracker'), new_object_url, :id => 'admin_new_tracker_link' %>
     </li>
   <% end %>
 <% end %>
@@ -24,7 +24,7 @@
       <tr data-hook="admin_trackers_index_headers">
         <th><%= Spree::Tracker.human_attribute_name(:analytics_id) %></th>
         <th><%= Spree::Tracker.human_attribute_name(:active) %></th>
-        <th><%= Spree.t(:store) %></th>
+        <th><%= I18n.t('spree.store') %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -32,7 +32,7 @@
       <% @trackers.each do |tracker|%>
         <tr id="<%= spree_dom_id tracker %>" data-hook="admin_trackers_index_rows" class="<%= cycle('odd', 'even')%>">
           <td class="align-center"><%= tracker.analytics_id %></td>
-          <td class="align-center"><%= tracker.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+          <td class="align-center"><%= tracker.active ? I18n.t('spree.say_yes') : I18n.t('spree.say_no') %></td>
           <td><%= tracker.store.name %></td>
           <td class="actions">
             <% if can?(:update, tracker) %>

--- a/app/views/spree/admin/trackers/new.html.erb
+++ b/app/views/spree/admin/trackers/new.html.erb
@@ -1,9 +1,9 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
-<% admin_breadcrumb(Spree.t(:settings)) %>
-<% admin_breadcrumb(Spree.t(:general_settings)) %>
+<% admin_breadcrumb(I18n.t('spree.settings')) %>
+<% admin_breadcrumb(I18n.t('spree.general_settings')) %>
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Tracker), spree.admin_trackers_path) %>
-<% admin_breadcrumb(Spree.t(:new_tracker)) %>
+<% admin_breadcrumb(I18n.t('spree.new_tracker')) %>
 
 <% content_for :page_actions do %>
 <% end %>

--- a/solidus_trackers.gemspec
+++ b/solidus_trackers.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'rubocop', '0.43.0'
+  s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
This patch aims to:

* Add Solidus v2.8 to Travis config
* Update rubocop to fix vulnerability [CVE-2017-8418](https://nvd.nist.gov/vuln/detail/CVE-2017-8418)
* Do not run `rubocop` when running specs
* Fix deprecation warnings

As per @kennyadsl's request, this PR also removes support for Solidus v2.3 as tomorrow (**01/31/19**) is the last day before reaching EOL; this patch should only be merged **past** the date previously mentioned.