### PR TITLE
Replace `I18n.t` with `t` in views

### DIFF
--- a/app/views/spree/admin/trackers/_form.html.erb
+++ b/app/views/spree/admin/trackers/_form.html.erb
@@ -12,11 +12,11 @@
         <ul>
           <li>
             <%= radio_button(:tracker, :active, true) %>
-            <%= label_tag :tracker_active_true, I18n.t('spree.say_yes') %>
+            <%= label_tag :tracker_active_true, t('spree.say_yes') %>
           </li>
           <li>
             <%= radio_button(:tracker, :active, false) %>
-            <%= label_tag :tracker_active_false, I18n.t('spree.say_no') %>
+            <%= label_tag :tracker_active_false, t('spree.say_no') %>
           </li>
         </ul>
       </div>

--- a/app/views/spree/admin/trackers/edit.html.erb
+++ b/app/views/spree/admin/trackers/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
-<% admin_breadcrumb(I18n.t('spree.settings')) %>
-<% admin_breadcrumb(I18n.t('spree.general_settings')) %>
+<% admin_breadcrumb(t('spree.settings')) %>
+<% admin_breadcrumb(t('spree.general_settings')) %>
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Tracker), spree.admin_trackers_path) %>
 <% admin_breadcrumb(@tracker.analytics_id) %>
 

--- a/app/views/spree/admin/trackers/index.html.erb
+++ b/app/views/spree/admin/trackers/index.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
-<% admin_breadcrumb(I18n.t('spree.settings')) %>
-<% admin_breadcrumb(I18n.t('spree.general_settings')) %>
+<% admin_breadcrumb(t('spree.settings')) %>
+<% admin_breadcrumb(t('spree.general_settings')) %>
 <% admin_breadcrumb(plural_resource_name(Spree::Tracker)) %>
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Tracker) %>
     <li>
-      <%= link_to I18n.t('spree.new_tracker'), new_object_url, :id => 'admin_new_tracker_link' %>
+      <%= link_to t('spree.new_tracker'), new_object_url, :id => 'admin_new_tracker_link' %>
     </li>
   <% end %>
 <% end %>
@@ -24,7 +24,7 @@
       <tr data-hook="admin_trackers_index_headers">
         <th><%= Spree::Tracker.human_attribute_name(:analytics_id) %></th>
         <th><%= Spree::Tracker.human_attribute_name(:active) %></th>
-        <th><%= I18n.t('spree.store') %></th>
+        <th><%= t('spree.store') %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -32,7 +32,7 @@
       <% @trackers.each do |tracker|%>
         <tr id="<%= spree_dom_id tracker %>" data-hook="admin_trackers_index_rows" class="<%= cycle('odd', 'even')%>">
           <td class="align-center"><%= tracker.analytics_id %></td>
-          <td class="align-center"><%= tracker.active ? I18n.t('spree.say_yes') : I18n.t('spree.say_no') %></td>
+          <td class="align-center"><%= tracker.active ? t('spree.say_yes') : t('spree.say_no') %></td>
           <td><%= tracker.store.name %></td>
           <td class="actions">
             <% if can?(:update, tracker) %>

--- a/app/views/spree/admin/trackers/new.html.erb
+++ b/app/views/spree/admin/trackers/new.html.erb
@@ -1,9 +1,9 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
-<% admin_breadcrumb(I18n.t('spree.settings')) %>
-<% admin_breadcrumb(I18n.t('spree.general_settings')) %>
+<% admin_breadcrumb(t('spree.settings')) %>
+<% admin_breadcrumb(t('spree.general_settings')) %>
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Tracker), spree.admin_trackers_path) %>
-<% admin_breadcrumb(I18n.t('spree.new_tracker')) %>
+<% admin_breadcrumb(t('spree.new_tracker')) %>
 
 <% content_for :page_actions do %>
 <% end %>


### PR DESCRIPTION
The helper `t` has a few key advantages in respect to `I18n.t` when used in
views:

* it ensures that any thrown `MissingTranslation` message is rendered as inline
  spans
* if the key starts with a period, `t` will scope the key by the current
  partial
* the translation will be marked as `html_safe` if the key has the suffix
  “_html” or the last element of the key is “html”