### PR TITLE
Fix add-to-store migration

### DIFF
--- a/db/migrate/20160920231000_add_store_to_tracker.rb
+++ b/db/migrate/20160920231000_add_store_to_tracker.rb
@@ -1,4 +1,4 @@
-class AddStoreToTracker < SolidusSupport::Migration[4.2][5.0]
+class AddStoreToTracker < SolidusSupport::Migration[4.2]
   def self.up
     if data_source_exists?('spree_trackers')
       change_table :spree_trackers do |t|


### PR DESCRIPTION
This migration had the same `[4.2][5.0]` referenced in #21 