### PR TITLE
Add deface gem

### DIFF
--- a/solidus_trackers.gemspec
+++ b/solidus_trackers.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'solidus_core', ['>= 2.1.0.alpha', '< 3']
   s.add_dependency "solidus_support"
+  s.add_dependency 'deface'
 
   s.add_development_dependency 'capybara', '~> 2.18'
   s.add_development_dependency 'poltergeist'


### PR DESCRIPTION
I think most Solidus installs eventually get a `deface`. But this extension doesn't have it in the spec, though it uses deface.